### PR TITLE
Add keyboard support and create fix for image URLs containing parentheses

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,8 @@
   "main": "photo-gallery.html",
   "dependencies": {
     "polymer": "^2.0.0",
-    "animejs": "^2.2.0"
+    "animejs": "^2.2.0",
+    "iron-a11y-keys": "PolymerElements/iron-a11y-keys#^2.0.0"
   },
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",

--- a/photo-gallery.html
+++ b/photo-gallery.html
@@ -1,5 +1,6 @@
 <link rel='import' href='../polymer/polymer-element.html'>
 <link rel='import' href='../shadycss/apply-shim.html'>
+<link rel="import" href="../iron-a11y-keys/iron-a11y-keys.html">
 
 <link rel='import' href='anime.html'>
 <link rel='import' href='photo-gallery-icon.html'>
@@ -98,6 +99,9 @@
       }
     </style>
 
+    <iron-a11y-keys target="[[keyEventTarget]]" keys="left up" on-keys-pressed="previous"></iron-a11y-keys>
+    <iron-a11y-keys target="[[keyEventTarget]]" keys="right down" on-keys-pressed="next"></iron-a11y-keys>
+
     <div class='grid' on-click='open'>
       <slot id='grid'></slot>
     </div>
@@ -140,6 +144,9 @@
             type: Number,
             value: -1,
             notify: true
+          },
+          keyEventTarget: {
+            type: Object
           }
         }
       }
@@ -264,6 +271,7 @@
 
       ready () {
         super.ready()
+        this.keyEventTarget = document.body
 
         let grid = this.$.grid
         this.updateItems()

--- a/photo-gallery.html
+++ b/photo-gallery.html
@@ -174,7 +174,7 @@
           let aspectRatio = this.getAspectRatio(url)
           item.style.width = this.height * aspectRatio + 'px'
           item.style.height = this.height + 'px'
-          item.style.backgroundImage = `url(${url})`
+          item.style.backgroundImage = `url('${url}')`
         })
       }
 


### PR DESCRIPTION
Implement `iron-a11y-keys`. Now you can press `left `or `up` arrow keys to show the previous image and `right `or `down` to show the next image in the slideshow.

Fixes #12 and fixes #13 